### PR TITLE
Make listening ports configurable, always use latest tracking ID

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,8 @@ import (
 type Options struct {
 	ProxyDomain          *string `json:"proxyDomain"`
 	ListeningAddress     *string `json:"listeningAddress"`
+	ListeningPortHTTP    *int    `json:"listeningPortHTTP"`
+	ListeningPortHTTPS   *int    `json:"listeningPortHTTPS"`
 	ProxyAddress     	 *string `json:"proxyAddress"`
 	Target               *string `json:"target"`
 	TargetRes            *string `json:"targetResources"`
@@ -56,6 +58,8 @@ var (
 	C = Options{
 		ProxyDomain:      flag.String("proxyDomain", "", "Proxy domain name that will be used - e.g.: proxy.tld"),
 		ListeningAddress: flag.String("listeningAddress", "127.0.0.1", "Listening address - e.g.: 0.0.0.0 "),
+		ListeningPortHTTP: flag.Int("listeningPortHTTP", 80, "Listening port for HTTP requests"),
+		ListeningPortHTTPS: flag.Int("listeningPortHTTPS", 443, "Listening port for HTTPS requests"),
 		Target:           flag.String("target", "", "Target  domain name  - e.g.: target.tld"),
 		TargetRes: flag.String("targetRes", "",
 			"Comma separated list of domains that were not translated automatically. Use this to force domain translation - e.g.: static.target.tld"),

--- a/core/helper.go
+++ b/core/helper.go
@@ -63,8 +63,8 @@ func deflateBuffer(input []byte) []byte {
 // Do a redirect
 func Redirect(w http.ResponseWriter, r *http.Request, url string) {
 	if len(url) > 0 {
-		http.Redirect(w, r, url, 301)
+		http.Redirect(w, r, url, 302)
 	} else {
-		http.Redirect(w, r, "http://"+runtime.TopLevelDomain, 301)
+		http.Redirect(w, r, "http://"+runtime.TopLevelDomain, 302)
 	}
 }

--- a/core/server.go
+++ b/core/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/drk1wi/Modlishka/runtime"
 	"net"
 	"net/http"
+	"strconv"
 )
 
 var ServerRuntimeConfig *ServerConfig
@@ -203,7 +204,9 @@ func RunServer() {
 	plugin.RegisterHandler(ServerRuntimeConfig.Handler)
 
 	var listener= string(*ServerRuntimeConfig.ListeningAddress)
-
+	var portHTTP = strconv.Itoa(*ServerRuntimeConfig.ListeningPortHTTP)
+	var portHTTPS = strconv.Itoa(*ServerRuntimeConfig.ListeningPortHTTPS)
+	
 	welcome := fmt.Sprintf(`
 %s
 
@@ -213,7 +216,7 @@ Author: Piotr Duszynski @drk1wi
 
 	if *ServerRuntimeConfig.ForceHTTP  {
 
-		var httplistener = listener + ":80"
+		var httplistener = listener + ":" + portHTTP
 		welcome = fmt.Sprintf("%s\nListening on [%s]\nProxying HTTP [%s] via --> [http://%s]", welcome, httplistener, runtime.Target, runtime.ProxyDomain)
 		log.Infof("%s", welcome)
 
@@ -234,7 +237,7 @@ Author: Piotr Duszynski @drk1wi
 
 		embeddedTLSServer.Handler = ServerRuntimeConfig.Handler
 
-		var httpslistener= listener + ":443"
+		var httpslistener= listener + ":" + portHTTPS
 
 		welcome = fmt.Sprintf("%s\nListening on [%s]\nProxying HTTPS [%s] via [https://%s]", welcome, httpslistener, runtime.Target, runtime.ProxyDomain)
 
@@ -260,11 +263,11 @@ Author: Piotr Duszynski @drk1wi
 			var HTTPServerRuntimeConfig = &ServerConfig{
 				Options: ServerRuntimeConfig.Options,
 				Handler: ServerRuntimeConfig.Handler,
-				Port:    "80",
+				Port:    portHTTP,
 			}
 
-			var httpslistener= listener + ":443"
-			var httplistener= listener + ":80"
+			var httpslistener= listener + ":" + portHTTPS
+			var httplistener= listener + ":" + portHTTP
 
 			welcome = fmt.Sprintf("%s\nListening on [%s]\nProxying HTTPS [%s] via [https://%s]", welcome, httpslistener, runtime.Target, runtime.ProxyDomain)
 			welcome = fmt.Sprintf("%s\nListening on [%s]\nProxying HTTP [%s] via [http://%s]", welcome, httplistener, runtime.Target, runtime.ProxyDomain)


### PR DESCRIPTION
The first change is a minor one: instead of using hardcoded ports for HTTP and HTTPS, I added two new options that allow overriding these (this should address #191). The second one is a little more involved, and tries to fix a rare edge case. Consider the following request sequence:

1. User follows first link, request with tracking ID = 1
2. User follows first link again, request with tracking ID = 1
3. User follows second link, request with tracking ID = 2
4. User follows first link again, request with tracking ID = 1

Without my fixes, the tracking ID is stored during the first request in a cookie, all other requests receive a HTTP 301 permanent redirect to a URL without a tracking ID. All requests are treated as if they were made with tracking ID = 1. So first, I fixed the logic that issues the redirects, so now they only redirect when the tracking ID in the cookie and the query string is the same. Otherwise, the tracking ID in the query string takes effect and the cookie is overwritten with the new value. This gets correct results all the way through step 3, but then at step 4 the browser skips the original link altogether, remembering the permanent redirect and not even bothering to send the tracking ID. So I changed the redirect to a HTTP 302 redirect which prevents this from happening.

