### PR TITLE
Updating Generated Certificat's Valid period

### DIFF
--- a/plugin/autocert.go
+++ b/plugin/autocert.go
@@ -124,7 +124,7 @@ func init() {
 						CommonName:   *config.C.ProxyDomain,
 					},
 					NotBefore: time.Now(),
-					NotAfter:  time.Now().AddDate(5, 5, 5),
+					NotAfter:  time.Now().AddDate(1, 0, 0),
 				}
 
 				// generate private key


### PR DESCRIPTION
Google Chrome has a requirement that SSL certs be valid only for 398 days or less. The changes made to autocert will cause it to generate certificates inline with Chrome's requirements and therefor usable by Google Chrome.

[Chromium - Certificate Lifetimes](https://chromium.googlesource.com/chromium/src/+/HEAD/net/docs/certificate_lifetimes.md)
[Stack Overflow - NET::ERR_CERT_VALIDITY_TOO_LONG](https://stackoverflow.com/questions/64597721/neterr-cert-validity-too-long-the-server-certificate-has-a-validity-period-t)