### PR TITLE
Removed unnecessary CGo import cause issues with undefined core package during install

### DIFF
--- a/core/server.go
+++ b/core/server.go
@@ -14,7 +14,6 @@
 
 package core
 
-import "C"
 import (
 	"crypto/tls"
 	"crypto/x509"


### PR DESCRIPTION
Multiple users are experiencing the following issue during installation:
`main.go:75:7: undefined: core.SetServerRuntimeConfig`
`main.go:81:7: undefined: core.RunServer`

Using Claude Sonnet 3.5 I was able to trace this issue back to the CGo import in the `server.go` file. Removing the import, which is not used, the installation ran without problems.

According to Claude Sonnet:

> The import "C" statement in Go is used for CGo, which is a feature that allows Go programs to call C code. It's a special import that tells the Go compiler to enable CGo processing and allows for interoperability with C libraries.
> 
> In this case:
> - There were no actual CGo function calls or C code dependencies visible in the [server.go](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) file
> - The package was importing "C" but not using any C functions or types
> - More importantly, when this import is placed before other imports in a multi-import block (as it was in this case), it can cause compilation issues because the "C" import has special requirements about its placement and usage
>
> The presence of import "C" without any actual C code usage was likely:
> - Either a leftover from some previous development where C interop was planned but not implemented
> - Or an accidental addition that wasn't caught because the code might have worked on some configurations despite the unused import
>
> You can verify that removing it was safe because:
> - The project builds successfully now
> - Looking at the code in server.go, it's purely Go code dealing with HTTP servers, TLS configuration, and proxy functionality
> - None of the functionality in this file requires C library integration
> - The project's go.mod doesn't show any dependencies that would require CGo
>
> If the project actually needed CGo functionality in the future, the "C" import would need to be added along with the necessary C code and proper CGo comments and directives. But for now, removing the unused import has fixed the build issue without affecting any functionality.