### PR TITLE
Append CA certificate to create a complete chain which allows clients to verify the server certificate

### DIFF
--- a/plugin/autocert.go
+++ b/plugin/autocert.go
@@ -158,6 +158,7 @@ func init() {
 
 				buf = new(bytes.Buffer)
 				pem.Encode(buf, &pem.Block{Type: "CERTIFICATE", Bytes: cert})
+				pem.Encode(buf, &pem.Block{Type: "CERTIFICATE", Bytes: catls.Certificate[0]})
 
 				tlscertStr := buf.String()
 				config.C.TLSCertificate = &tlscertStr


### PR DESCRIPTION
This prevents the "TLS handshake error".